### PR TITLE
v2.0.1

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "SpectreVRC",
-  "version": "2.0.0-2",
+  "version": "2.0.1",
   "identifier": "com.angelware.spectre",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -180,7 +180,7 @@
 				<DropdownMenu.Separator />
 				<DropdownMenu.Item on:click={logout}>Logout</DropdownMenu.Item>
 				<DropdownMenu.Separator />
-				<DropdownMenu.Item disabled>v2.0.0-ALPHA</DropdownMenu.Item>
+				<DropdownMenu.Item disabled>v2.0.1-ALPHA</DropdownMenu.Item>
 			</DropdownMenu.Content>
 		</DropdownMenu.Root>
 	</div>


### PR DESCRIPTION
Bumps version to no longer use semver suffix, this was causing issues with Tauri's updater, so we will stick with something more standard from now on.